### PR TITLE
Using $jwks_uri instead of $oidcconfig['jwks_uri'] when getting keydata

### DIFF
--- a/src/AAD/IDToken.php
+++ b/src/AAD/IDToken.php
@@ -73,7 +73,7 @@ class IDToken extends \remotelearner\aadsample\OIDC\IDToken {
             $jwks_uri = 'https://login.windows.net/common/discovery/keys';
         }
 
-        $keydata = $httpclient->get($oidcconfig['jwks_uri']);
+        $keydata = $httpclient->get($jwks_uri);
         $keydata = @json_decode($keydata, true);
         if (empty($keydata) || !is_array($keydata) || !isset($keydata['keys'])) {
             throw new AADSAMPLEException('Could not get openid connect config (2).');


### PR DESCRIPTION
The jwks_uri variable should be the one used to get the keydata because the tenantid is default to null and therefore $oidcconfig['jwks_uri'] is not always set.
Therefore it'll throw 'Invalid URL in HttpClient' when processing idtoken when running the sample.